### PR TITLE
update dependency version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,12 +9,12 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.5)
-    ffi (1.9.23)
+    ffi (1.9.24)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.3)
+    jekyll (3.7.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -65,7 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.7.3)
+  jekyll (~> 3.7.4)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data


### PR DESCRIPTION
Updated Jekyl and ffi version numbers to address identified security issues.

* ffi:     1.9.23 -> 1.9.24 
* jekyl: 3.7.4   ->  3.7.4